### PR TITLE
Python 2 compatibility and redis fixes.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='celery-beatx',
-    version='0.4.1a3',
+    version='0.4.1a1',
     url='https://github.com/mixkorshun/celery-beatx',
     description='Modern fail-safe schedule for Celery',
     keywords=['celery', 'celery-beat', 'scheduler'],


### PR DESCRIPTION
Fixed - Issue where it would attempt to import redis in the store/redis.py overlapping naming...
Fixed - super() calls.
Fixed - An issue where py2 didn't like the class being the same type as renamed parent. Hence BeatXScheduler rename.
Fixed - Import urllib urlparse.
I think the lock cycle time is too high by default but to each his own.